### PR TITLE
Switch from Oracle JDK 10 to OpenJDK 10 + add OpenJDK 11 and EA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - openjdk11
   - openjdk10
   - oraclejdk9
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk10
+  - openjdk10
   - oraclejdk9
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: java
 jdk:
+  - openjdk-ea
   - openjdk11
   - openjdk10
   - oraclejdk9
   - oraclejdk8
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Had to also bump javac source/target level to 1.7, as [1.6 is no longer supported under JDK 12](https://www.oracle.com/technetwork/java/javase/12-relnote-issues-5211422.html#JDK-8028563).