### PR TITLE
Added OSGi metadata support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,7 @@
         <version>2.3.1</version>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Specification-Version>${project.version}</Specification-Version>
-            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <addMavenDescriptor>false</addMavenDescriptor>
           </archive>
         </configuration>
@@ -130,6 +128,26 @@
             <goals>
               <goal>jar</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>5.1.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+Specification-Version: ${version}
+Bundle-SymbolicName: org.zeroturnaround.zt-process-killer
+Export-Package:\
+ org.zeroturnaround.process.*
+           ]]></bnd>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Currently the library can't be used in OSGi environments because there is no OSGi metadata available. With this pull request the maven build is modified that the resulting jar file contains all necessary OSGi metadata in the META-INF/MANIFEST.MF file.

I also recommend an upgrade of the JNA library to at least >=5.0.0 because the OSGi metadata of dependent libraries is important too (not mandatory). JNA 4.2.2 (current version) has OSGi metadata but it's mediocre, since 5.0.0 is got much better.