### PR TITLE
Drop the unused commons-io runtime dependency

### DIFF
--- a/3rd-party-licenses.txt
+++ b/3rd-party-licenses.txt
@@ -3,8 +3,8 @@ ZT Process contains other open-source 3rd party software which are copyrighted t
 parties and are licensed under different terms and conditions. Reference to the websites of the
 corresponding vendors for additional details.
 
-* Copyright for Commons IO 2.2 and Commons Lang 2.6 is held by Apache Software Foundation.
-  Copyright for ZT Exec 1.7 is held by ZeroTurnaround Inc.
+* Copyright for Commons Lang is held by Apache Software Foundation.
+  Copyright for ZT Exec is held by ZeroTurnaround Inc.
   They are all licensed under the Apache Software License, version 2.0:
   
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `commons-io` is no longer a dependency of the published artifact. Nothing under `src/main` references it, so it is now a test-only dependency and no longer appears in the POM. `zt-exec` and `commons-lang3` are used from the main sources and stay runtime-scoped. Add a direct dependency if you were relying on `commons-io` arriving transitively.
+
 ## [1.12.0] - 2026-07-10
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,19 +51,18 @@ dependencies {
   api(libs.jna)
   api(libs.slf4j.api)
 
-  // zt-exec, commons-lang3 and commons-io are used only inside method bodies and
-  // never appear in any exported signature, so they are `implementation`:
-  // consumers get them transitively at runtime but not on their compile classpath.
-  // This narrows the transitive compile scope versus the old POM, where the
-  // default `compile` scope put all of them on consumers' compile classpath.
-  // (commons-io is in fact referenced only from the test sources today, but it
-  // was a published runtime dependency, so it stays on the runtime classpath to
-  // preserve the artifact contract.)
+  // zt-exec and commons-lang3 are used only inside method bodies and never appear
+  // in any exported signature, so they are `implementation`: consumers get them
+  // transitively at runtime but not on their compile classpath. This narrows the
+  // transitive compile scope versus the old POM, where the default `compile` scope
+  // put them on consumers' compile classpath.
   implementation(libs.zt.exec)
   implementation(libs.commons.lang3)
-  implementation(libs.commons.io)
 
   testImplementation(libs.junit)
+  // commons-io is used only by the tests: nothing under src/main references it, as
+  // the generated OSGi Import-Package header shows.
+  testImplementation(libs.commons.io)
   // slf4j-simple is the slf4j binding for tests: no transitive dependencies and
   // released in lockstep with slf4j-api, so there is no separate version to track.
   testRuntimeOnly(libs.slf4j.simple)


### PR DESCRIPTION
Closes #40.

`commons-io` was declared as a runtime dependency of the published artifact, but nothing under `src/main` references it — only the test sources use it. This moves the declaration to `testImplementation`, which removes it from the published POM.

An unused runtime dependency still appears in every consumer's dependency tree, so scanners flag consumers for CVEs in a library no code path can reach. That is what produced the CVE-2021-29425 report in #27.

`zt-exec` and `commons-lang3` are genuinely used from the main sources, so they remain runtime-scoped. This change is specific to `commons-io`.

### Verification

The generated OSGi `Import-Package` header is byte-for-byte identical before and after, which is the strongest evidence available that nothing in the bundle loaded `commons-io`: bnd derives the header from compiled bytecode, and it never listed `org.apache.commons.io`.

```
Import-Package: com.sun.jna;version="[5.19,6)",com.sun.jna.win32;version="[5.19,6)",
 java.io,java.lang,java.lang.management,java.lang.reflect,java.util,
 java.util.concurrent,java.util.regex,org.apache.commons.lang3;version="[3.20,4)",
 org.slf4j;version="[1.7,2)",org.zeroturnaround.exec;version="[1.13,2)",
 org.zeroturnaround.exec.stream.slf4j;version="[1.13,2)"
```

The generated POM now resolves to:

| Dependency | Scope |
| --- | --- |
| `net.java.dev.jna:jna:5.19.1` | compile |
| `org.slf4j:slf4j-api:1.6.3` | compile |
| `org.zeroturnaround:zt-exec:1.13.0` | runtime |
| `org.apache.commons:commons-lang3:3.20.0` | runtime |

`./gradlew clean build` passes: 61 tests, no failures.

### Compatibility

This is a visible change to the artifact's dependency set, so it is noted in the changelog under Changed. The practical risk is low: any consumer that *compiled* against `commons-io` without declaring it was already broken by the compile-to-runtime narrowing in 1.12.0. A consumer still working after that upgrade uses `commons-io` only at runtime, and nothing in this artifact triggers such use.

### Points for review

- `3rd-party-licenses.txt` listed `commons-io`, so it is removed there as no longer distributed. I also dropped the version numbers from the two remaining entries: they had drifted well out of date (it said Commons Lang 2.6 while the build uses commons-lang3 3.20.0, and ZT Exec 1.7 while the build uses 1.13.0), and keeping them means editing that file on every dependency bump. Happy to restore accurate version numbers instead if you would rather keep them.
- Pre-existing and deliberately not addressed here: that same file does not mention `jna`, which *is* distributed and is dual-licensed (LGPL 2.1 / Apache 2.0). Worth a separate look, but it is a licensing call rather than a build one.
