### PR TITLE
Scan the workflow files with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,33 +11,45 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (java)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Workflow files: nothing to compile, so CodeQL reads the sources directly.
+          - language: actions
+            build-mode: none
+          - language: java-kotlin
+            build-mode: manual
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Java
+        if: matrix.build-mode == 'manual'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 24
 
       - name: Set up Gradle
+        if: matrix.build-mode == 'manual'
         uses: gradle/actions/setup-gradle@v6.2.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.37.4
         with:
-          languages: java-kotlin
-          build-mode: manual
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Build
+        if: matrix.build-mode == 'manual'
         run: ./gradlew compileJava --no-daemon
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.4
         with:
-          category: "/language:java-kotlin"
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
CodeQL only looked at the compiled sources. The workflow files under `.github/` were never analysed, even though they are the part of the repository that holds permissions, handles the publishing credentials and runs code from pull requests.

Adds an `actions` leg to the existing job as a matrix:

| language | build mode |
| --- | --- |
| `actions` | `none` — nothing to compile, CodeQL reads the sources directly |
| `java-kotlin` | `manual` — unchanged from before |

The Java, Gradle and build steps are gated on `matrix.build-mode == 'manual'`, so the `actions` leg skips them. Action pins and the build command are untouched.