### PR TITLE
Point references at the renamed default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
   schedule:
     # Weekly scan to catch newly published queries against unchanged code.
     - cron: '23 4 * * 1'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,7 +4,7 @@ name: Dependency Submission
 # raise security alerts (and updates) for vulnerable transitive dependencies.
 on:
   push:
-    branches: [master, main]
+    branches: [main]
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -68,25 +68,25 @@ We had the following functional requirements:
 
 * check whether a process is alive
 * wait until a process has finished
-* terminate a process gracefully (by default disabled on Windows as it's unsupported - [WindowsProcess](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/WindowsProcess.java))
+* terminate a process gracefully (by default disabled on Windows as it's unsupported - [WindowsProcess](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/WindowsProcess.java))
 * terminate a process forcibly
 * get the process ID (PID) of running JVM
 
 and these non-functional requirements:
 
-* abstraction of processes regardless they are started from Java or not (use process ID) - [SystemProcess](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/SystemProcess.java)
+* abstraction of processes regardless they are started from Java or not (use process ID) - [SystemProcess](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/SystemProcess.java)
 * have process API similar to [java.lang.Process](https://docs.oracle.com/javase/8/docs/api/java/lang/Process.html) 
 * all waiting methods should have one version with timeout and another without it 
 * stopping operation should be idempotent - if a process was already finished it is a success 
-* separate generic behavior from process implementation - [ProcessUtil](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/ProcessUtil.java)
-* support alternative implementations for stopping same process - [OrProcess](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/OrProcess.java)
-* simple factory for creating process instances - [Processes](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/Processes.java)
-* invoke Java 8 **java.lang.Process** methods if possible - [Java8Process](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/Java8Process.java)
+* separate generic behavior from process implementation - [ProcessUtil](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/ProcessUtil.java)
+* support alternative implementations for stopping same process - [OrProcess](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/OrProcess.java)
+* simple factory for creating process instances - [Processes](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/Processes.java)
+* invoke Java 8 **java.lang.Process** methods if possible - [Java8Process](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/Java8Process.java)
 
 Limitations:
 
 * As the process abstraction is also used for already running processes it can't access their streams or exit value.
-* The scope of this project is stopping single processes. However [WindowsProcess](https://github.com/zeroturnaround/zt-process-killer/blob/master/src/main/java/org/zeroturnaround/process/WindowsProcess.java)
+* The scope of this project is stopping single processes. However [WindowsProcess](https://github.com/zeroturnaround/zt-process-killer/blob/main/src/main/java/org/zeroturnaround/process/WindowsProcess.java)
 has method **setIncludeChildren** to also stop child processes in case the root process is still running.
 
 ### Examples


### PR DESCRIPTION
The default branch was renamed from `master` to `main`.

- Workflow triggers listed both names to allow for the rename; `master` no longer exists, so only `main` remains.
- README source links pointed at `/blob/master/` and relied on GitHub's redirect.